### PR TITLE
[BugFix] Add `instruction-doc` key in default config

### DIFF
--- a/checkers/default_config.py
+++ b/checkers/default_config.py
@@ -21,5 +21,6 @@ checker_default_config = {
             "ios": None,
             "ios-common": None,
         },
+        "instruction-doc": None,
     },
 }


### PR DESCRIPTION
Add `instruction-doc` key in default config